### PR TITLE
commandFromHistory now accounts for 0 indexing

### DIFF
--- a/src/app/widgets/console/console.widget.ts
+++ b/src/app/widgets/console/console.widget.ts
@@ -84,15 +84,15 @@ export class ConsoleWidgetComponent implements WidgetComponent {
       };
     }
     const history = this.configManager.getConfig().history;
-    const clampedIndex = Math.max(Math.min(index, history.length), 0);
-    if (clampedIndex <= 0) {
+    const clampedIndex = Math.max(Math.min(index, history.length - 1), -1);
+    if (clampedIndex < 0) {
       return {
         message: '',
-        index: clampedIndex,
+        index: -1,
       };
     } else {
       return {
-        message: history[history.length - clampedIndex],
+        message: history[history.length - clampedIndex - 1],
         index: clampedIndex,
       };
     }


### PR DESCRIPTION
**Not sure how/where to add tests for this change, but I would be happy to do so with some advice!

Changes the commandFromHistory method to work in zero indexing when using the history array in reverse. Index of -1 still acts as normal (waiting for user input) while index 0 will bring the final command in the array (the most recently issued command).

Fix For: #12 