### PR TITLE
removed ngmodel provider on show last directive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wolfpack-rpg-client",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wolfpack-rpg-client",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "license": "GPL-3.0-or-later",
   "scripts": {
     "ng": "ng",

--- a/src/app/directives/show-last.directive.ts
+++ b/src/app/directives/show-last.directive.ts
@@ -7,7 +7,6 @@ import { NgModel } from '@angular/forms';
  */
 @Directive({
   selector: '[appShowLast]',
-  providers: [NgModel],
 })
 export class ShowLastDirective implements OnInit {
   constructor(private elem: ElementRef, private model: NgModel) {}


### PR DESCRIPTION
Fixed a bug where the console widget no longer automatically scrolled to the bottom when receiving messages