### PR TITLE
Feature/message delay fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules\\typescript\\lib"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wolfpack-rpg-client",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "license": "GPL-3.0-or-later",
   "scripts": {
     "ng": "ng",

--- a/src/app/services/command/command-service.ts
+++ b/src/app/services/command/command-service.ts
@@ -27,7 +27,8 @@ export type CommandCallback = (
   id: string,
   groups: Map<string, string>,
   subGroups: Array<Map<string, string>>,
-  date: number
+  date: number,
+  isReplay?: boolean
 ) => void;
 
 /**
@@ -314,7 +315,8 @@ export class CommandService {
           match.value.id,
           match.value.params,
           match.value.subParams,
-          match.value.date
+          match.value.date,
+          true
         );
       }
     }

--- a/src/app/services/irc/irc.service.ts
+++ b/src/app/services/irc/irc.service.ts
@@ -38,7 +38,7 @@ export class IrcService {
   /**
    * The message queue that handles rate limits on messages sent.
    */
-  messageQueue = new MessageQueue(ircConfig.botAccount, 400);
+  messageQueue = new MessageQueue(ircConfig.botAccount, 500);
   /**
    * Whether or not the IRC client is connected.
    */

--- a/src/app/services/irc/irc.service.ts
+++ b/src/app/services/irc/irc.service.ts
@@ -38,7 +38,7 @@ export class IrcService {
   /**
    * The message queue that handles rate limits on messages sent.
    */
-  messageQueue = new MessageQueue(ircConfig.botAccount, 100);
+  messageQueue = new MessageQueue(ircConfig.botAccount, 400);
   /**
    * Whether or not the IRC client is connected.
    */
@@ -173,7 +173,7 @@ export class IrcService {
       this.messageQueue.setCheckFn(() => {
         return this.isConnected;
       });
-      this.messageQueue.start();
+      await this.messageQueue.start();
       this.connection.on('raw_message', message => {
         const tag = message.tags['msg-id'] ? message.tags['msg-id'] : undefined;
         if (message.command === 'NOTICE' && tag === 'whisper_restricted') {

--- a/src/app/services/irc/irc.service.ts
+++ b/src/app/services/irc/irc.service.ts
@@ -64,10 +64,6 @@ export class IrcService {
     this.broadcastMessage(new Message(message, self));
   }
 
-  private onSendMessage(message: string): void {
-    this.broadcastMessage(new Message(message, true));
-  }
-
   private onError(message: string): void {
     const messageObj = new Message(message, false);
     for (const [key, value] of this.errorHandlers) {
@@ -180,7 +176,7 @@ export class IrcService {
       this.messageQueue.registerSendCallback(
         'irc-client',
         (message: string) => {
-          this.onSendMessage(message);
+          this.onWhisper(message, true);
         }
       );
       await this.messageQueue.start();

--- a/src/app/services/irc/message-queue.spec.ts
+++ b/src/app/services/irc/message-queue.spec.ts
@@ -109,4 +109,25 @@ describe('MessageQueue', () => {
     await queue.processQueue();
     expect(spy).toHaveBeenCalled();
   });
+
+  it('should call registered callbacks when message is sent', async () => {
+    const message = `test message sent at ${Date.now()}`;
+    const sendFn = {
+      send: (account: string, message: string): Promise<[string, string]> => {
+        return new Promise(resolve => {
+          resolve(['', '']);
+        });
+      },
+    };
+    const queue = new MessageQueue('spec-test', 100);
+    queue.setSendFunction(sendFn.send);
+    const callbackFn = {
+      callback: (message: string): void => {},
+    };
+    const spy = spyOn(callbackFn, 'callback');
+    queue.registerSendCallback('spec-test', callbackFn.callback);
+    queue.send(message);
+    await queue.processQueue();
+    expect(spy).toHaveBeenCalled();
+  });
 });

--- a/src/app/services/irc/message-queue.ts
+++ b/src/app/services/irc/message-queue.ts
@@ -21,7 +21,7 @@ export class MessageQueue {
   private checkFn: CheckFunction | undefined;
   private sendCallbacks = new Map<string, SendCallback>();
   private minimumDelay = 600;
-  private lastSend = Date.now();
+  private lastSend = 0;
 
   /**
    * The list of messages to send through the queue.
@@ -40,9 +40,7 @@ export class MessageQueue {
     );
   }
 
-  constructor(private account: string, private rate: number) {
-    console.log('Creating a new message queue');
-  }
+  constructor(private account: string, private rate: number) {}
 
   private canSend(): boolean {
     if (this.checkFn) {

--- a/src/app/services/irc/message-queue.ts
+++ b/src/app/services/irc/message-queue.ts
@@ -1,5 +1,4 @@
 import { RollingTimer } from './rolling-timer';
-import { Client } from 'tmi.js';
 
 export type SendFunction = (
   account: string,

--- a/src/app/services/irc/message-queue.ts
+++ b/src/app/services/irc/message-queue.ts
@@ -36,7 +36,9 @@ export class MessageQueue {
     );
   }
 
-  constructor(private account: string, private rate: number) {}
+  constructor(private account: string, private rate: number) {
+    console.log('Creating a new message queue');
+  }
 
   private canSend(): boolean {
     if (this.checkFn) {
@@ -69,7 +71,7 @@ export class MessageQueue {
     if (this.queue.length > 0) {
       const limit = Math.min(this.queue.length, this.availableOccurrences);
       if (limit > 0) {
-        await this.sendMessages(limit);
+        await this.sendMessages(1);
       }
     }
     if (this.timer) {
@@ -129,8 +131,8 @@ export class MessageQueue {
   /**
    * Starts the message queue.
    */
-  start(): void {
-    this.processQueue();
+  async start(): Promise<void> {
+    await this.processQueue();
     this.continue();
   }
 

--- a/src/app/util/utils.ts
+++ b/src/app/util/utils.ts
@@ -163,31 +163,45 @@ export class Utils {
    * @param date A string containing a datetime value
    */
   static parseDateFromBot(date: string | undefined): Date {
-    if (!date) {
-      return new Date(Date.now());
+    if (date) {
+      const dateString = date as string;
+      if (Utils.timezoneDelta === -1) {
+        const millisInMinute = 60 * 1000;
+        const now = new Date(Date.now());
+        const serverOffset =
+          this.getTimeZoneOffset(now, 'America/Chicago') * millisInMinute;
+        const localOffset = now.getTimezoneOffset() * millisInMinute;
+        Utils.timezoneDelta = serverOffset - localOffset;
+      }
+
+      const parse = /([0-9]{1,2})\/([0-9]{1,2})\/([0-9]{4}) ([0-9]{1,2}):([0-9]{1,2}):([0-9]{1,2})((?: PM)?)/;
+      const values = dateString.match(parse);
+
+      if (values) {
+        const month = parseInt(values[1]);
+        const day = parseInt(values[2]);
+        const year = parseInt(values[3]);
+
+        let hour = parseInt(values[4]);
+        const minute = parseInt(values[5]);
+        const second = parseInt(values[6]);
+
+        if (values[7].length > 0) {
+          hour += 12;
+        }
+
+        const normalized = new Date(
+          year,
+          month - 1,
+          day,
+          hour,
+          minute,
+          second,
+          0
+        );
+        return new Date(normalized.getTime() + Utils.timezoneDelta);
+      }
     }
-    if (Utils.timezoneDelta === -1) {
-      const millisInMinute = 60 * 1000;
-      const now = new Date(Date.now());
-      const serverOffset =
-        this.getTimeZoneOffset(now, 'America/Chicago') * millisInMinute;
-      const localOffset = now.getTimezoneOffset() * millisInMinute;
-      Utils.timezoneDelta = serverOffset - localOffset;
-    }
-
-    const month = parseInt(date.substring(0, 2));
-    const day = parseInt(date.substring(3, 5));
-    const year = parseInt(date.substring(6, 10));
-
-    let hour = parseInt(date.substring(11, 13));
-    const minute = parseInt(date.substring(14, 16));
-    const second = parseInt(date.substring(17, 19));
-
-    if (date.endsWith('PM')) {
-      hour += 12;
-    }
-
-    const normalized = new Date(year, month - 1, day, hour, minute, second, 0);
-    return new Date(normalized.getTime() + Utils.timezoneDelta);
+    return new Date(Date.now());
   }
 }

--- a/src/app/widgets/fishing/fishing.widget.ts
+++ b/src/app/widgets/fishing/fishing.widget.ts
@@ -218,7 +218,8 @@ export class FishingWidgetComponent extends AbstractWidgetComponent {
     id: string,
     groups: Map<string, string>,
     subGroups: Array<Map<string, string>>,
-    date: number
+    date: number,
+    isReplay?: boolean
   ): void {
     if (id === 'timeLeft') {
       const time = (groups.get('time') ?? '00:00:00').split(':');
@@ -241,7 +242,9 @@ export class FishingWidgetComponent extends AbstractWidgetComponent {
       if (!this.tournament) {
         console.log('No tournament currently active, create one');
         this.tournament = new Tournament();
-        this.commandService?.sendCommand('fishing', 'results');
+        if (!isReplay) {
+          this.commandService?.sendCommand('fishing', 'results');
+        }
       }
       this.nextTournament = new Date(date + toAdd);
       console.log(`Set time for next tournament to ${this.nextTournament}`);

--- a/src/app/widgets/fishing/fishing.widget.ts
+++ b/src/app/widgets/fishing/fishing.widget.ts
@@ -367,8 +367,8 @@ export class FishingWidgetComponent extends AbstractWidgetComponent {
       'responses',
       'success',
       id,
-      (name, id, groups, subGroups, date) =>
-        this.handleNext(name, id, groups, subGroups, date)
+      (name, id, groups, subGroups, date, isReplay) =>
+        this.handleNext(name, id, groups, subGroups, date, isReplay)
     );
 
     commandService.subscribeToCommand(

--- a/src/app/widgets/fishing/fishing.widget.ts
+++ b/src/app/widgets/fishing/fishing.widget.ts
@@ -232,16 +232,19 @@ export class FishingWidgetComponent extends AbstractWidgetComponent {
       this.tournament.endTime = new Date(date + toAdd);
       this.nextTournament = undefined;
     } else if (id === 'toNext') {
+      console.log(`Time to next tournament: ${groups.get('time')}`);
       const time = (groups.get('time') ?? '00:00:00').split(':');
       const toAdd =
         parseInt(time[0]) * 60 * 60 * 1000 +
         parseInt(time[1]) * 60 * 1000 +
         parseInt(time[2]) * 1000;
       if (!this.tournament) {
+        console.log('No tournament currently active, create one');
         this.tournament = new Tournament();
         this.commandService?.sendCommand('fishing', 'results');
       }
       this.nextTournament = new Date(date + toAdd);
+      console.log(`Set time for next tournament to ${this.nextTournament}`);
       this.tournament.endTime = undefined;
     }
   }


### PR DESCRIPTION
- Fixed messages not being sent by added delay between messages
- Fixed messages showing up after their responses in the console
- Fixed tournament results being requests when commands are sent through the console when the fishing widget is open
- Fixed next tournament time showing NaN when parsing tournament results